### PR TITLE
Escape < in url/title to prevent injecting HTML formatting into extension

### DIFF
--- a/app/scripts/popup.coffee
+++ b/app/scripts/popup.coffee
@@ -15,7 +15,7 @@ window.tabahead = ($, fuzzy, chrome, setTimeout, storage) ->
         pre: '<strong class="text-info">'
         post: '</strong>'
         extract: (el) ->
-            "#{el.title}#{string_separator}#{el.url}"
+            "#{el.title}#{string_separator}#{el.url}".replace(/</g, '&lt;')
 
     source = (query, process) ->
         queryInfo = currentWindow: true


### PR DESCRIPTION
This would be a potential XSS in older Chrome extensions, now it can only be an annoyance.
