### PR TITLE
Equalize margins for popup search dialog

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1,9 +1,12 @@
 body {
     background-image: -webkit-gradient(linear, left bottom, left top, color-stop(0, rgb(238, 238, 238)), color-stop(1, rgb(248, 248, 248)));
+    margin-left: 4px;
+    margin-right: 4px;
 }
 
 .navbar-search {
     width: 500px;
+    height: 35px;
 }
 
 .title {
@@ -21,6 +24,7 @@ body {
 
 .dropdown-menu {
     background-color: rgb(233, 233, 233);
+    margin-bottom: 4px;
 }
 
 .dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:focus, .dropdown-menu>li>a:hover, .dropdown-menu>li>a:focus, .dropdown-submenu:hover>a, .dropdown-submenu:focus>a {


### PR DESCRIPTION
Quick css change to smooth out the look of the popup.

Old:
<img width="535" alt="old" src="https://cloud.githubusercontent.com/assets/6148924/11175189/73780fb2-8bfd-11e5-9286-5f07868647df.png">

New:
<img width="545" alt="new" src="https://cloud.githubusercontent.com/assets/6148924/11175192/7a552a72-8bfd-11e5-97f5-92b75a847081.png">
