### PR TITLE
Add FireFox specific information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,34 @@ Tab Ahead [![Pay me][paypal-svg]][paypal-dot-me] [![Sponsor me][github-sponsors-
 ==============================
 [![Build Status](https://travis-ci.org/janraasch/tab-ahead.svg?branch=master)](https://travis-ci.org/janraasch/tab-ahead) [![Coverage Status](https://img.shields.io/coveralls/janraasch/tab-ahead.svg)](https://coveralls.io/r/janraasch/tab-ahead?branch=master)
 
-Lightweight [Chrome Extension](https://chrome.google.com/webstore/detail/tab-ahead/naoajjeoiblmpegfelhkapanmmaaghmi) that helps you to quickly find open tabs by title and url.
+Lightweight [Chrome Extension][chrome-extension-url] / [FireFox Add-On][firefox-addon-url] that helps you to quickly find open tabs by title and url.
 
 *Bringing Visual Studio Code's `Goto Anything...` to your Browser Tabs.*
 
 Installation
 ------------
 
-Go to the [Tab Ahead](https://chrome.google.com/webstore/detail/tab-ahead/naoajjeoiblmpegfelhkapanmmaaghmi) page on the [Chrome Web Store](https://chrome.google.com/webstore/) and click `Add To Chrome`.
+[![Available on FireFox ADD-ONS][firefox-addons-image]][firefox-addon-url]
+
+[![Available in Chrome Web Store][chrome-web-store-image]][chrome-extension-url]
 
 
 Keyboard Shortcut
 -------------------
-* Press `Alt+T` to quickly open the search dialog.
-* Go to [chrome://extensions](chrome://extensions) and click `Keyboard shortcuts`/`Configure Commands` to change or remove the default shortcut.
+Press `Alt+T` to quickly open the search dialog.
+
+**FireFox**: Go to [about:addons](about:addons), click on the »gear-icon« in the upper right corner of the page and select `Manage Extension Shortcuts` to change or remove the default shortcut.
+
+
+**Chrome**: Go to [chrome://extensions](chrome://extensions), open the menu on the left side by clicking on the »burger«-icon on the upper left corner of the page. Then click on `Keyboard shortcuts` to change or remove the default shortcut.
 
 Options
 ---------
-Choose whether to search in the context of the current window or over all (non-incognito) windows. Go to [chrome://extensions](chrome://extensions) and click the `Options` link next to the extension.
+Choose whether to search in the context of the current window or over all (non-incognito) windows.
+
+**FireFox**: Go to [about:addons](about:addons) and select »Tab Ahead«. Then click on `Preferences` to get to the »options«-page.
+
+**Chrome**: Go to [chrome://extensions](chrome://extensions), click the `Details` link next to the extension. Then click `Extension options` to get to the »options«-page.
 
 Sponsor 💟
 ----------
@@ -86,7 +96,7 @@ This project and its contents are open source under the MIT license.
 [github-sponsors]: https://github.com/sponsors/janraasch
 [paypal-svg]: https://img.shields.io/badge/onetime-donation-11dde2.svg?logo=paypal
 [github-sponsors-svg]: https://img.shields.io/badge/recurring-sponsorship-ee4aaa.svg?logo=github
-[firefox-addon-url]: https://addons.mozilla.org/en-US/developers/addon/tab-ahead-firefox
+[firefox-addon-url]: https://addons.mozilla.org/en-US/firefox/addon/tab-ahead-firefox/
 [chrome-extension-url]: https://chrome.google.com/webstore/detail/tab-ahead/naoajjeoiblmpegfelhkapanmmaaghmi
-[chrome-web-store-image]: ./assets/app_store_icons/ChromeWebStore_BadgeWBorder_v2_206x58.png
-[firefox-addons-image]: ./assets/app_store_icons/get-the-addon-178x60px.dad84b42.png
+[chrome-web-store-image]: https://raw.github.com/janraasch/tab-ahead/master/assets/app_store_icons/ChromeWebStore_BadgeWBorder_v2_206x58.png
+[firefox-addons-image]: https://raw.github.com/janraasch/tab-ahead/master/assets/app_store_icons/get-the-addon-178x60px.dad84b42.png

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Tab Ahead [![Pay me][paypal-svg]][paypal-dot-me] [![Sponsor me][github-sponsors-
 ==============================
 [![Build Status](https://travis-ci.org/janraasch/tab-ahead.svg?branch=master)](https://travis-ci.org/janraasch/tab-ahead) [![Coverage Status](https://img.shields.io/coveralls/janraasch/tab-ahead.svg)](https://coveralls.io/r/janraasch/tab-ahead?branch=master)
 
-Lightweight [Chrome Extension][chrome-extension-url] / [FireFox Add-On][firefox-addon-url] that helps you to quickly find open tabs by title and url.
+Lightweight [Chrome Extension][chrome-extension-url] / [Firefox Add-On][firefox-addon-url] that helps you to quickly find open tabs by title and url.
 
 *Bringing Visual Studio Code's `Goto Anything...` to your Browser Tabs.*
 
 Installation
 ------------
 
-[![Available on FireFox ADD-ONS][firefox-addons-image]][firefox-addon-url]
+[![Available on Firefox ADD-ONS][firefox-addons-image]][firefox-addon-url]
 
 [![Available in Chrome Web Store][chrome-web-store-image]][chrome-extension-url]
 
@@ -19,7 +19,7 @@ Keyboard Shortcut
 -------------------
 Press `Alt+T` to quickly open the search dialog.
 
-**FireFox**: Go to [about:addons](about:addons), click on the »gear-icon« in the upper right corner of the page and select `Manage Extension Shortcuts` to change or remove the default shortcut.
+**Firefox**: Go to [about:addons](about:addons), click on the »gear-icon« in the upper right corner of the page and select `Manage Extension Shortcuts` to change or remove the default shortcut.
 
 
 **Chrome**: Go to [chrome://extensions](chrome://extensions), open the menu on the left side by clicking on the »burger«-icon on the upper left corner of the page. Then click on `Keyboard shortcuts` to change or remove the default shortcut.
@@ -28,7 +28,7 @@ Options
 ---------
 Choose whether to search in the context of the current window or over all (non-incognito) windows.
 
-**FireFox**: Go to [about:addons](about:addons) and select »Tab Ahead«. Then click on `Preferences` to get to the »options«-page.
+**Firefox**: Go to [about:addons](about:addons) and select »Tab Ahead«. Then click on `Preferences` to get to the »options«-page.
 
 **Chrome**: Go to [chrome://extensions](chrome://extensions), click the `Details` link next to the extension. Then click `Extension options` to get to the »options«-page.
 
@@ -42,7 +42,7 @@ Support my work on this piece of open-source software via [GitHub Sponsors][gith
 
 Version History
 ------------
-* v1.3.1 - Initial release for FireFox. Previously this extension was only available on the Chrome browser. - **This is currently under review by the FireFox Team.**
+* v1.3.1 - Initial release for Firefox. Previously this extension was only available on the Chrome browser. - **This is currently under review by the Firefox Team.**
 * v1.3.0 - Improve fuzzy filter ([Fuse.js](http://kiro.me/projects/fuse.html)) and disable autocomplete on search input.
 * v1.2.2 - Equal margins for search input field.
 * v1.2.1 - Even faster popup response time.


### PR DESCRIPTION
I'll merge this, once the extension is available on https://addons.mozilla.org/en-US/firefox/extensions/.

# To-dos

- [x] Make this https://github.com/janraasch/tab-ahead/releases/tag/v1.3.1 a *non-pre* release **and** upload the build `.zip`.